### PR TITLE
Add header component

### DIFF
--- a/App.js
+++ b/App.js
@@ -5,10 +5,12 @@ import { Card } from 'react-native-paper';
 
 // or any files within the Snack
 import AssetExample from './components/AssetExample';
+import Header from './components/Header';
 
 export default function App() {
   return (
     <SafeAreaView style={styles.container}>
+      <Header />
       <Text style={styles.paragraph}>
         hello my name is amar
       </Text>
@@ -22,8 +24,9 @@ export default function App() {
 const styles = StyleSheet.create({
   container: {
     flex: 1,
-    justifyContent: 'center',
+    justifyContent: 'flex-start',
     backgroundColor: '#ecf0f1',
+    paddingTop: 60,
     padding: 8,
   },
   paragraph: {

--- a/README.md
+++ b/README.md
@@ -1,11 +1,19 @@
-# Sample Snack app
+# InCircle
 
-Open the `App.js` file to start writing some code. You can preview the changes directly on your phone or tablet by scanning the **QR code** or use the iOS or Android emulators. When you're done, click **Save** and share the link!
+InCircle is a mobile‑first, privacy‑focused real estate marketplace designed for
+Indian agents, brokers, builders and channel partners. It enables verified
+professionals to collaborate, share listings and respond to property demands
+within their trusted network.
 
-When you're ready to see everything that Expo provides (or if you want to use your own editor) you can **Download** your project and use it with [expo cli](https://docs.expo.dev/get-started/installation/#expo-cli)).
+This repository contains a minimal React Native/Expo project with a simple home
+screen. The app currently renders a basic header and example content. To start
+developing, edit `App.js` and run one of the provided Expo scripts:
 
-All projects created in Snack are publicly available, so you can easily share the link to this project via link, or embed it on a web page with the `<>` button.
+```bash
+npm start   # open Expo developer tools
+npm android # run on Android device or emulator
+npm ios     # run on iOS simulator
+npm web     # run in the browser
+```
 
-If you're having problems, you can tweet to us [@expo](https://twitter.com/expo) or ask in our [forums](https://forums.expo.dev/c/expo-dev-tools/61) or [Discord](https://chat.expo.dev/).
-
-Snack is Open Source. You can find the code on the [GitHub repo](https://github.com/expo/snack).
+Make sure you have the Expo CLI installed. See the [Expo documentation](https://docs.expo.dev) for full details.

--- a/app.json
+++ b/app.json
@@ -1,7 +1,7 @@
 {
   "expo": {
-    "name": "quiet-violet-candies",
-    "slug": "snack-51ca8fef-742d-4b58-afea-45652681c973",
+    "name": "InCircle",
+    "slug": "incircle",
     "version": "1.0.0",
     "orientation": "portrait",
     "icon": "./assets/icon.png",

--- a/components/Header.js
+++ b/components/Header.js
@@ -1,0 +1,33 @@
+import { View, Text, StyleSheet } from 'react-native';
+
+export default function Header() {
+  return (
+    <View style={styles.container}>
+      <Text style={styles.logo}>Your Trusted Network</Text>
+      {/* Future Icons (🔍, 🔔) */}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    position: 'absolute',
+    top: 0,
+    left: 0,
+    right: 0,
+    width: '100%',
+    backgroundColor: '#0F172A',
+    shadowColor: '#000',
+    shadowOffset: { width: 0, height: 2 },
+    shadowOpacity: 0.3,
+    shadowRadius: 2,
+    elevation: 3,
+    paddingVertical: 12,
+    alignItems: 'center',
+  },
+  logo: {
+    color: '#fff',
+    fontSize: 18,
+    fontWeight: 'bold',
+  },
+});


### PR DESCRIPTION
## Summary
- add a `Header` component styled as a sticky top bar
- display the new header in `App.js`
- fix header alignment to top by updating `Header` styles and container layout
- rename app to `InCircle`
- update README with basic setup instructions

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685ab32bd834832ab7527006fbe68028