### PR TITLE
Fix style for Expo

### DIFF
--- a/components/Header.js
+++ b/components/Header.js
@@ -11,8 +11,10 @@ export default function Header() {
 
 const styles = StyleSheet.create({
   container: {
-    position: 'sticky',
+    position: 'absolute',
     top: 0,
+    left: 0,
+    right: 0,
     width: '100%',
     backgroundColor: '#0F172A',
     shadowColor: '#000',
@@ -22,6 +24,7 @@ const styles = StyleSheet.create({
     elevation: 3,
     paddingVertical: 12,
     alignItems: 'center',
+    zIndex: 1,
   },
   logo: {
     color: '#fff',


### PR DESCRIPTION
## Summary
- fix header positioning style for Expo compatibility

## Testing
- `npm test` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685ac3f2594c832a929f3a08e2f123e9