### PR TITLE
Update expo-status-bar for SDK 52

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   },
   "dependencies": {
     "expo": "~53.0.12",
-    "expo-status-bar": "~2.2.3",
+    "expo-status-bar": "~2.0.1",
     "react": "19.0.0",
     "react-native": "0.79.4",
     "react-native-paper": "4.9.2",


### PR DESCRIPTION
## Summary
- use the recommended `expo-status-bar` version for Expo SDK 52

## Testing
- `npm install` *(fails: method is blocked)*

------
https://chatgpt.com/codex/tasks/task_e_685ac65c7970832ab35c13e19e60a3e1