### PR TITLE
Fix vector icon version for Expo 52

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "react": "19.0.0",
     "react-native": "0.79.4",
     "react-native-paper": "4.9.2",
-    "@expo/vector-icons": "^14.1.0"
+    "@expo/vector-icons": "^14.0.2"
   },
   "devDependencies": {
     "@babel/core": "^7.20.0"


### PR DESCRIPTION
## Summary
- use `@expo/vector-icons` version recommended for Expo SDK 52

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685aca9bc8f4832ab080e9c4825b19e3