### PR TITLE
Fix missing default export in index.js

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,3 +6,6 @@ import App from './App';
 // It also ensures that whether you load the app in Expo Go or in a native build,
 // the environment is set up appropriately
 registerRootComponent(App);
+
+// Export App for environments that expect a default export
+export default App;


### PR DESCRIPTION
## Summary
- ensure that `index.js` exports the `App` component so environments that expect a default export can render it

## Testing
- `npm --version`

------
https://chatgpt.com/codex/tasks/task_e_685accb1e35c832abcfd293f4603aed1