### PR TITLE
Disable new architecture causing PlatformConstants error

### DIFF
--- a/app.json
+++ b/app.json
@@ -6,7 +6,7 @@
     "orientation": "portrait",
     "icon": "./assets/icon.png",
     "userInterfaceStyle": "light",
-    "newArchEnabled": true,
+    "newArchEnabled": false,
     "splash": {
       "image": "./assets/splash-icon.png",
       "resizeMode": "contain",


### PR DESCRIPTION
## Summary
- disable React Native's new architecture setting in `app.json`

## Testing
- `npm install`
- `npx expo --version`

------
https://chatgpt.com/codex/tasks/task_e_685ae017d200832a9bf80179c308fce1