### PR TITLE
Add Expo error documentation excerpts

### DIFF
--- a/expo_errors_info/debugging_errors-and-warnings.txt
+++ b/expo_errors_info/debugging_errors-and-warnings.txt
@@ -1,0 +1,70 @@
+Errors and warnings
+Edit this page
+Learn about Redbox errors and stack traces in your Expo project.
+Edit this page
+When developing an application using Expo, you'll encounter a 
+Redbox
+ error or 
+Yellowbox
+ warning. These logging experiences are provided by 
+LogBox in React Native
+.
+
+
+Redbox error and Yellowbox warning
+
+
+A Redbox error is displayed when a fatal error prevents your app from running. A Yellowbox warning is displayed to inform you that there is a possible issue and you should probably resolve it before shipping your app.
+
+
+You can also create warnings and errors on your own with 
+console.warn("Warning message")
+ and 
+console.error("Error message")
+. Another way to trigger the redbox is to throw an error and not catch it: 
+throw Error("Error message")
+.
+
+
+
+
+This is a brief introduction to debugging a React Native app with Expo CLI. For in-depth information, see 
+Debugging
+.
+
+
+
+
+Stack traces
+
+
+When you encounter an error during development, you'll see the error message and a 
+stack trace
+, which is a report of the recent calls your application made when it crashed. This stack trace is shown both in your terminal and the Expo Go app or if you have created a development build.
+
+
+This stack trace is 
+extremely valuable
+ since it gives you the location of the error's occurrence. For example, in the following image, the error comes from the file 
+HomeScreen.js
+ and is caused on line 7 in that file.
+
+
+
+
+When you look at that file, on line 7, you will see that a variable called 
+renderDescription
+ is referenced. The error message describes that the variable is not found because the variable is not declared in 
+HomeScreen.js
+. This is a typical example of how helpful error messages and stack traces can be if you take the time to decipher them.
+
+
+Debugging errors is one of the most frustrating but satisfying parts of development. Remember that you're never alone. The 
+Expo community
+ and the React and React Native communities are great resources for help when you get stuck. There's a good chance someone else has run into your exact error. Make sure to read the documentation, search the 
+forums
+, 
+GitHub issues
+, and 
+Stack Overflow
+.

--- a/expo_errors_info/eas-update_error-recovery.txt
+++ b/expo_errors_info/eas-update_error-recovery.txt
@@ -1,0 +1,197 @@
+Error recovery
+Edit this page
+Learn how to take advantage of using built-in error recovery when using expo-updates library.
+Edit this page
+Apps using 
+expo-updates
+ can take advantage of built-in error recovery behavior as an extra safeguard against accidentally publishing broken updates.
+
+
+While we cannot stress enough the importance of testing updates in a staging environment before publishing to production, humans (and even computers) occasionally make mistakes, and the error recovery behavior described here can serve as a last resort in such cases.
+
+
+ 
+Disclaimer:
+ The behavior documented below is subject to change and should not be relied upon. Always test your code carefully and thoroughly in production-like environments before publishing updates.
+
+
+Help! I published a broken update to production. What should I do?
+
+
+First of all, don't panic. Mistakes happen; most likely, everything will be fine.
+
+
+The important thing is to 
+publish a new update with a fix as soon as possible (though not before you are 100% confident in your fix).
+ The error recovery mechanism in 
+expo-updates
+ will ensure that in most cases, even users who have already downloaded the broken update should be able to get the fix.
+
+
+The first thing to try is rolling back to an older update that you know was working. 
+However, this may not always be safe;
+ your broken update may, for example, have modified persistent state (such as data stored in AsyncStorage or on the device's file system) in a non-backwards-compatible way. It's important to test in a staging environment that emulates an end user's device state as closely as possible to load the broken update and then roll back.
+
+
+If you can identify an older update that is safe to roll back to, you can do so using EAS Update's 
+republish
+ option from 
+EAS dashboard
+ or 
+EAS CLI
+.
+
+
+If you cannot identify an older update that is safe to roll back to, you'll need to fix it forward. While it's best to roll out a fix as quickly as possible, you should take the time to ensure your fix is solid, and know that even users who download your broken update in the meantime should be able to download your fix.
+
+
+If you'd like more details about how this works, read on.
+
+
+Explaining the error recovery flow
+
+
+The error recovery flow is intended to be as lightweight as possible. It is not a full safety net that protects your end users from the results of errors; in many cases, users will still see a crash.
+
+
+Rather, the purpose is to prevent updates from "bricking" your app (causing a crash on launch before the app can check for updates, making the app unusable until uninstalled and reinstalled) by ensuring that in as many cases as possible, the app has the opportunity to download a new update and fix itself.
+
+
+Catching an error
+
+
+If your app throws a fatal error when executing JS which is early enough in the app's lifecycle that it may prevent the app from being able to download further updates, 
+expo-updates
+ will catch this error.
+
+
+
+
+If more than 10 seconds have elapsed between your app's first render and the time a fatal error is thrown, 
+expo-updates
+ will not catch this error at all and none of the error recovery code will be triggered. Therefore, we highly recommend that your app check for updates very shortly after launching, whether automatically or manually to ensure you can push out fixes in the event of a future error.
+
+
+
+
+If 
+expo-updates
+ catches a JS error, what will happen next depends on whether React Native has fired the native "content appeared" event (
+ReactMarkerConstants.CONTENT_APPEARED
+ on Android or 
+RCTContentDidAppearNotification
+ on iOS) â approximately when your app's first view has been rendered on the screen, for this particular update, either on this launch or a previous one.
+
+
+
+
+Why this distinction?
+ In some cases 
+expo-updates
+ may try to automatically roll back to an older (working) update, but this can be dangerous if your new update has modified persistent state in a non-backwards compatible way. We assume that if the error occurs before the first view has rendered, no such code has been able to execute, and so rolling back is safe. After this point 
+expo-updates
+ will only fix forward and will not roll back.
+
+
+
+
+If content has appeared
+
+
+If an error is caught and the "content appeared" event has already fired, OR if it has ever been fired on this device on a past launch of the same update, the following will happen:
+
+
+
+
+A 5 second timer will be started, and (unless 
+EXUpdatesCheckOnLaunch
+/
+expo.modules.updates.EXPO_UPDATES_CHECK_ON_LAUNCH
+ is set to 
+NEVER
+) the app will check for a new update and download it if there is one.
+
+
+If there is no new update, the update finishes downloading, or the timer runs out (whichever happens first), the app will throw the original error and crash.
+
+
+
+
+Note that if a new update is downloaded, it will launch when the user next tries to open the app.
+
+
+If content has not appeared
+
+
+If an error is caught before the "content appeared" event has fired, and this is the first time the current update is being launched on this device, the following will happen:
+
+
+
+
+The update will be marked as "failed" locally and will not be launched again on this device.
+
+
+A 5 second timer will be started, and (unless 
+EXUpdatesCheckOnLaunch
+/
+expo.modules.updates.EXPO_UPDATES_CHECK_ON_LAUNCH
+ is set to 
+NEVER
+) the app will check for a new update and download it if there is one.
+
+
+If a new update finishes downloading before the timer runs out, the app will immediately try to reload itself and launch the newly downloaded update.
+
+
+If this newly downloaded update also throws a fatal error, or there is no new update, or the timer runs out, the app will immediately try to reload by rolling back to an older update, whichever one was most recently launched successfully.
+
+
+If this also fails, or there is no older update available on the device, the app will throw the original error and crash.
+
+
+
+
+Error stacktraces
+
+
+If your app encounters a fatal JS error, and the error recovery system cannot recover, it will re-throw the original exception to cause a crash. The stacktrace will look similar to this:
+
+
+Android
+iOS
+--------- beginning of crash
+AndroidRuntime: FATAL EXCEPTION: expo-updates-error-recovery
+AndroidRuntime: Process: com.myapp.MyApp, PID: 12498
+AndroidRuntime: com.facebook.react.common.JavascriptException
+AndroidRuntime:
+AndroidRuntime: 	at com.facebook.react.modules.core.ExceptionsManagerModule.reportException(ExceptionsManagerModule.java:72)
+AndroidRuntime: 	at java.lang.reflect.Method.invoke(Native Method)
+AndroidRuntime: 	at com.facebook.react.bridge.JavaMethodWrapper.invoke(JavaMethodWrapper.java:372)
+AndroidRuntime: 	at com.facebook.react.bridge.JavaModuleWrapper.invoke(JavaModuleWrapper.java:188)
+AndroidRuntime: 	at com.facebook.react.bridge.queue.NativeRunnable.run(Native Method)
+AndroidRuntime: 	at android.os.Handler.handleCallback(Handler.java:938)
+AndroidRuntime: 	at android.os.Handler.dispatchMessage(Handler.java:99)
+AndroidRuntime: 	at com.facebook.react.bridge.queue.MessageQueueThreadHandler.dispatchMessage(MessageQueueThreadHandler.java:27)
+AndroidRuntime: 	at android.os.Looper.loop(Looper.java:223)
+AndroidRuntime: 	at com.facebook.react.bridge.queue.MessageQueueThreadImpl$4.run(MessageQueueThreadImpl.java:228)
+AndroidRuntime: 	at java.lang.Thread.run(Thread.java:923)
+
+On Android, the stacktrace of the original exception is preserved. Depending on your crash reporting service, you may or may not need to reproduce the crash locally to see more information about the underlying error.
+Last Exception Backtrace:
+0   CoreFoundation                	0xf203feba4 __exceptionPreprocess + 220 (NSException.m:200)
+1   libobjc.A.dylib               	0xf201a1be7 objc_exception_throw + 60 (objc-exception.mm:565)
+2   MyApp                         	0x10926b7ee -[EXUpdatesAppController throwException:] + 24 (EXUpdatesAppController.m:422)
+3   MyApp                         	0x109280352 -[EXUpdatesErrorRecovery _crash] + 984 (EXUpdatesErrorRecovery.m:222)
+4   MyApp                         	0x10927fa3d -[EXUpdatesErrorRecovery _runNextTask] + 148 (EXUpdatesErrorRecovery.m:0)
+5   libdispatch.dylib             	0x109bc1848 _dispatch_call_block_and_release + 32 (init.c:1517)
+6   libdispatch.dylib             	0x109bc2a2c _dispatch_client_callout + 20 (object.m:560)
+7   libdispatch.dylib             	0x109bc93a6 _dispatch_lane_serial_drain + 668 (inline_internal.h:2622)
+8   libdispatch.dylib             	0x109bca0bc _dispatch_lane_invoke + 392 (queue.c:3944)
+9   libdispatch.dylib             	0x109bd6472 _dispatch_workloop_worker_thread + 648 (queue.c:6732)
+10  libsystem_pthread.dylib       	0xf6da2845d _pthread_wqthread + 288 (pthread.c:2599)
+11  libsystem_pthread.dylib       	0xf6da2742f start_wqthread + 8
+
+Even though it appears the exception was thrown from expo-updates, this stacktrace generally indicates 
+an error that originated in JavaScript
+.
+Unfortunately, Apple's crash reporting does not include the exception message, which details the underlying error and its location in JavaScript. To see the message and help you narrow down the issue, you may need to reproduce the crash locally with the Xcode debugger or macOS Console app attached.

--- a/expo_errors_info/router_error-handling.txt
+++ b/expo_errors_info/router_error-handling.txt
@@ -1,0 +1,311 @@
+Error handling
+Edit this page
+Learn how to handle unmatched routes and errors in your app when using Expo Router.
+Edit this page
+This guide specifies how to handle unmatched routes and errors in your app when using Expo Router.
+
+
+Unmatched routes
+
+
+
+
+Native apps don't have a server so there are technically no 404s. However, if you're implementing a router universally, then it makes sense to handle missing routes. This is done automatically for each app, but you can also customize it.
+
+
+app/+not-found.tsx
+Copy
+import
+ 
+{
+ 
+Unmatched
+ 
+}
+ 
+from
+ 
+'expo-router'
+;
+
+
+export
+ 
+default
+ 
+Unmatched
+;
+
+
+
+
+This will render the default 
+Unmatched
+. You can export any component you want to render instead. We recommend having a link to 
+/
+ so users can navigate back to the home screen.
+
+
+Route priority
+
+
+On web, files are served in the following order:
+
+
+
+
+Static files in the 
+public
+ directory.
+
+
+Standard and dynamic routes in the app directory.
+
+
+API routes
+ in the app directory.
+
+
+Not-found routes will be served last with a 404 status code.
+
+
+
+
+Error handling
+
+
+Expo Router enables fine-tuned error handling to enable a more opinionated data-loading strategy in the future.
+
+
+
+
+You can export a nested 
+ErrorBoundary
+ component from any route to intercept and format component-level errors using 
+React Error Boundaries
+:
+
+
+
+
+app/home.tsx
+Copy
+import
+ 
+{
+ 
+View
+,
+ 
+Text
+ 
+}
+ 
+from
+ 
+'react-native'
+;
+
+
+import
+ 
+{
+ 
+type
+ 
+ErrorBoundaryProps
+ 
+}
+ 
+from
+ 
+'expo-router'
+;
+
+
+
+export
+ 
+function
+ 
+ErrorBoundary
+(
+{
+ error
+,
+ retry 
+}
+:
+ 
+ErrorBoundaryProps
+)
+ 
+{
+
+  
+return
+ 
+(
+
+    
+<
+View
+ 
+style
+=
+{
+{
+ flex
+:
+ 
+1
+,
+ backgroundColor
+:
+ 
+"red"
+ 
+}
+}
+>
+
+      
+<
+Text
+>
+{
+error
+.
+message
+}
+</
+Text
+>
+
+      
+<
+Text
+ 
+onPress
+=
+{
+retry
+}
+>
+Try Again?
+</
+Text
+>
+
+    
+</
+View
+>
+
+  
+)
+;
+
+
+}
+
+
+
+export
+ 
+default
+ 
+function
+ 
+Page
+(
+)
+ 
+{
+ 
+...
+ 
+}
+
+
+
+
+When you export an 
+ErrorBoundary
+ the route will be wrapped with a React Error Boundary effectively:
+
+
+Virtual
+Copy
+function
+ 
+Route
+(
+{
+ 
+ErrorBoundary
+,
+ 
+Component
+ 
+}
+)
+ 
+{
+
+  
+return
+ 
+(
+
+    
+<
+Try
+ 
+catch
+=
+{
+ErrorBoundary
+}
+>
+
+      
+<
+Component
+ 
+/>
+
+    
+</
+Try
+>
+
+  
+)
+;
+
+
+}
+
+
+
+
+When 
+ErrorBoundary
+ is not present, the error will be thrown to the nearest parent's 
+ErrorBoundary
+ and accepts 
+error
+ and 
+retry
+ props.
+
+
+Work in progress
+
+
+React Native LogBox needs to be presented less aggressively to develop with errors. Currently, it shows for 
+console.error
+ and 
+console.warn
+. However, it should ideally only show for uncaught errors.

--- a/expo_errors_info/workflow_common-development-errors.txt
+++ b/expo_errors_info/workflow_common-development-errors.txt
@@ -1,0 +1,120 @@
+Common development errors
+Edit this page
+A list of common development errors that are encountered by developers using Expo.
+Edit this page
+This page outlines a list of errors that are commonly encountered by developers using Expo. For each error, the first bullet provides an explanation for why the error occurs and the second bullet contains debugging suggestions. If there is an error you think belongs here, we welcome and encourage you to 
+create a PR
+!
+
+
+Metro bundler ECONNREFUSED 127.0.0.1:19001
+
+
+
+
+An error is preventing the connection to your local development server.
+
+
+Run 
+rm -rf .expo
+ to clear your local state. Check for firewalls or 
+proxies
+ affecting the network you are currently connected to.
+
+
+
+
+Module AppRegistry is not a registered callable module (calling runApplication)
+
+
+
+
+An error in your code is preventing the JavaScript bundle from being executed on startup.
+
+
+Try running 
+npx expo start --no-dev --minify
+ to reproduce the production JS bundle locally. If possible, connect your device and access the device logs via Android Studio or Xcode. Device logs contain much more detailed stacktraces and information. Check to see if you have any changes or errors in your Babel configuration. In some rare cases, this issue could be caused by incompatibility between the Metro JavaScript minifier and certain code in your app (
+more information
+).
+
+
+
+
+npm ERR! No git binary found in $PATH
+
+
+
+
+Either you do not have git installed or it is not properly configured in your 
+$PATH
+.
+
+
+Install git
+ if you have not already. Otherwise, check how to set it in your 
+$PATH
+ based on your OS.
+
+
+
+
+XX.X.X is not a valid SDK version
+
+
+
+
+The SDK version you are running has been deprecated and is no longer supported.
+
+
+Upgrade your project
+ to a supported SDK version. If you are using a supported version and see this message, you'll need to update your Expo Go app.
+
+
+
+
+React Native version mismatch
+
+
+
+
+The development server running in your terminal is bundling a different version of React Native than the app in your device or simulator.
+
+
+Align your versions of react-native
+ by checking the versions in your 
+app.json
+ and 
+package.json
+
+
+
+
+Application has not been registered
+
+
+
+
+There is a mismatch between the AppKey registered in the native and JS portion of your app.
+
+
+Align your AppKey
+ with the native side of your project.
+
+
+
+
+Application not behaving as expected
+
+
+
+
+It is possible caches may be preventing you from seeing the current state of your application.
+
+
+Clear all caches associated with your project in 
+Unix-like
+ or 
+Windows
+ systems.
+


### PR DESCRIPTION
## Summary
- add offline copies of Expo docs pages with information on error handling, recovery and debugging

## Testing
- `python3 -c "import bs4,requests"`


------
https://chatgpt.com/codex/tasks/task_e_685b63b763b4832ab3a4f4cf3cdcb9e8