### PR TITLE
Fix navigation setup for Snack

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,10 @@
+import 'react-native-gesture-handler';
 import { registerRootComponent } from 'expo';
+import { enableScreens } from 'react-native-screens';
 
 import App from './App';
+
+enableScreens();
 
 // registerRootComponent calls AppRegistry.registerComponent('main', () => App);
 // It also ensures that whether you load the app in Expo Go or in a native build,

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "@react-navigation/native": "^6.1.9",
     "@react-navigation/bottom-tabs": "^6.5.17",
     "@react-navigation/native-stack": "^6.9.12",
-    "react-native-safe-area-context": "5.4.0"
+    "react-native-safe-area-context": "5.4.0",
+    "react-native-gesture-handler": "~2.12.1"
   }
 }


### PR DESCRIPTION
## Summary
- set up React Navigation properly for Snack Expo
- add `react-native-gesture-handler` dependency

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685b64e901dc832a8be508e28f6ad3db